### PR TITLE
Update output format of cli commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## [0.0.10] - 2023.01.26
+
+### Changed
+
+- Removed extra message from CLI commands.
+  ([#8](https://github.com/ryanking13/auditwheel-emscripten/pull/8))
+- Changed the output format of `exports` and `imports` CLI command in order to
+  make it easier to parse with `grep`.
+  ([#8](https://github.com/ryanking13/auditwheel-emscripten/pull/8))
+
 ## [0.0.9] - 2022.12.20
 
 ### Fixed

--- a/auditwheel_emscripten/__init__.py
+++ b/auditwheel_emscripten/__init__.py
@@ -3,7 +3,7 @@ from .imports import get_imports
 from .repair import copylib, repair, repair_extracted, resolve_sharedlib
 from .show import show, show_dylib, show_wheel
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 __all__ = [
     "repair",
     "repair_extracted",

--- a/auditwheel_emscripten/cli/main.py
+++ b/auditwheel_emscripten/cli/main.py
@@ -25,7 +25,6 @@ def _show(
     """
     try:
         dependencies = show(wheel_or_so_file)
-        rich.print("The following external shared libraries are required:")
         pprint(dependencies)
     except Exception as e:
         raise e
@@ -51,7 +50,6 @@ def _repair(
             wheel_file, libdir, output_dir, modify_needed_section=True
         )
         dependencies = show(repaired_wheel)
-        rich.print("Repaired wheel has following external shared libraries:")
         pprint(dependencies)
     except RuntimeError as e:
         raise e
@@ -77,7 +75,6 @@ def _copy(
             wheel_file, libdir, output_dir, modify_needed_section=False
         )
         dependencies = show(repaired_wheel)
-        rich.print("Repaired wheel has following external shared libraries:")
         pprint(dependencies)
     except RuntimeError as e:
         raise e
@@ -94,8 +91,10 @@ def _exports(
     """
     try:
         exports = get_exports(wheel_or_so_file)
-        rich.print("It has following exports:")
-        pprint(exports)
+        for export in exports:
+            print(f"{export}:")
+            for symbol in exports[export]:
+                print(f"{symbol.kind.name:>10}\t{symbol.name}")
     except Exception as e:
         raise e
 
@@ -111,7 +110,9 @@ def _imports(
     """
     try:
         imports = get_imports(wheel_or_so_file)
-        rich.print("It has following imports:")
-        pprint(imports)
+        for _import in imports:
+            print(f"{_import}:")
+            for symbol in imports[_import]:
+                print(f"{symbol.module:>10}{symbol.kind.name:>10}\t{symbol.field}")
     except Exception as e:
         raise e

--- a/auditwheel_emscripten/cli/main.py
+++ b/auditwheel_emscripten/cli/main.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import rich
 import typer
 from rich.pretty import pprint
 

--- a/auditwheel_emscripten/exports.py
+++ b/auditwheel_emscripten/exports.py
@@ -1,12 +1,13 @@
 import tempfile
 from pathlib import Path
 
+from .emscripten_tools.webassembly import Export
 from .lib_utils import get_all_shared_libs_in_dir, sharedlib_regex
 from .module import _get_exports
 from .wheel_utils import is_emscripten_wheel, unpack
 
 
-def get_exports_dylib(dylib_file: Path) -> list[str]:
+def get_exports_dylib(dylib_file: Path) -> list[Export]:
     if dylib_file.read_bytes()[:4] not in (b"\0asm", b"asm\0"):
         raise RuntimeError(f"{dylib_file} is not a wasm file")
 
@@ -14,7 +15,9 @@ def get_exports_dylib(dylib_file: Path) -> list[str]:
     return exports
 
 
-def get_exports_wheel_unpacked(wheel_extract_dir: str | Path) -> dict[str, list[str]]:
+def get_exports_wheel_unpacked(
+    wheel_extract_dir: str | Path,
+) -> dict[str, list[Export]]:
     exports_map = {}
 
     shared_libs = get_all_shared_libs_in_dir(wheel_extract_dir)
@@ -25,7 +28,7 @@ def get_exports_wheel_unpacked(wheel_extract_dir: str | Path) -> dict[str, list[
     return exports_map
 
 
-def get_exports_wheel(wheel_file: Path) -> dict[str, list[str]]:
+def get_exports_wheel(wheel_file: Path) -> dict[str, list[Export]]:
 
     if not is_emscripten_wheel(wheel_file.name):
         raise RuntimeError(f"{wheel_file} is not an emscripten wheel")
@@ -37,7 +40,7 @@ def get_exports_wheel(wheel_file: Path) -> dict[str, list[str]]:
         return get_exports_wheel_unpacked(extract_dir)
 
 
-def get_exports(wheel_or_so_file: str | Path) -> dict[str, list[str]]:
+def get_exports(wheel_or_so_file: str | Path) -> dict[str, list[Export]]:
     file = Path(wheel_or_so_file)
     if not file.exists():
         raise RuntimeError(f"no such file: {file}")

--- a/auditwheel_emscripten/imports.py
+++ b/auditwheel_emscripten/imports.py
@@ -1,12 +1,13 @@
 import tempfile
 from pathlib import Path
 
+from .emscripten_tools.webassembly import Import
 from .lib_utils import get_all_shared_libs_in_dir, sharedlib_regex
 from .module import _get_imports
 from .wheel_utils import is_emscripten_wheel, unpack
 
 
-def get_imports_dylib(dylib_file: Path) -> list[str]:
+def get_imports_dylib(dylib_file: Path) -> list[Import]:
     if dylib_file.read_bytes()[:4] not in (b"\0asm", b"asm\0"):
         raise RuntimeError(f"{dylib_file} is not a wasm file")
 
@@ -14,7 +15,9 @@ def get_imports_dylib(dylib_file: Path) -> list[str]:
     return exports
 
 
-def get_imports_wheel_unpacked(wheel_extract_dir: str | Path) -> dict[str, list[str]]:
+def get_imports_wheel_unpacked(
+    wheel_extract_dir: str | Path,
+) -> dict[str, list[Import]]:
     exports_map = {}
 
     shared_libs = get_all_shared_libs_in_dir(wheel_extract_dir)
@@ -25,7 +28,7 @@ def get_imports_wheel_unpacked(wheel_extract_dir: str | Path) -> dict[str, list[
     return exports_map
 
 
-def get_imports_wheel(wheel_file: Path) -> dict[str, list[str]]:
+def get_imports_wheel(wheel_file: Path) -> dict[str, list[Import]]:
 
     if not is_emscripten_wheel(wheel_file.name):
         raise RuntimeError(f"{wheel_file} is not an emscripten wheel")
@@ -37,7 +40,7 @@ def get_imports_wheel(wheel_file: Path) -> dict[str, list[str]]:
         return get_imports_wheel_unpacked(extract_dir)
 
 
-def get_imports(wheel_or_so_file: str | Path) -> dict[str, list[str]]:
+def get_imports(wheel_or_so_file: str | Path) -> dict[str, list[Import]]:
     file = Path(wheel_or_so_file)
     if not file.exists():
         raise RuntimeError(f"no such file: {file}")


### PR DESCRIPTION
- Remove verbose output messages in CLI commands
- Change the output format of `exports` and `imports` command in order to make it easier to parse with `grep`.