### PR TITLE
add license file to distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "typer[all]",
     "wheel",
 ]
+license.file = "LICENSE"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Thanks for this tool!

This one-liner ensures the LICENSE is distributed along with the `.tar.gz`, useful for [downstream repackagers](https://github.com/conda-forge/staged-recipes/pull/22011) and _probably_ encouraged by the terms of the MPL-2.0.