### PR TITLE
Change repair command to not update dylink needed section and deprecate copy command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the bahavior of the `repair` command. It does not update `needed` section anymore
   and only copies the shared libraries to the wheel.
   Also, `copy` command is deprecated in favor of `repair`.
-  ([#25](https://github.com/ryanking13/auditwheel-emscripten/pull/25)) 
+  ([#25](https://github.com/ryanking13/auditwheel-emscripten/pull/25))
 
 ## [0.0.13] - 2023.06.08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Changed the bahavior of the `repair` command. It does not update `needed` section anymore
+- Changed the behavior of the `repair` command. It does not update `needed` section anymore
   and only copies the shared libraries to the wheel.
   Also, `copy` command is deprecated in favor of `repair`.
   ([#25](https://github.com/ryanking13/auditwheel-emscripten/pull/25))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.0.14] - 2023-12-23
+
+### Changed
+
+- Changed the bahavior of the `repair` command. It does not update `needed` section anymore
+  and only copies the shared libraries to the wheel.
+  Also, `copy` command is deprecated in favor of `repair`.
+  ([#25](https://github.com/ryanking13/auditwheel-emscripten/pull/25)) 
+
+## [0.0.13] - 2023.06.08
+
+- Added py.typed file.
+  ([#16](https://github.com/ryanking13/auditwheel-emscripten/pull/16))
+
 ## [0.0.12] - 2023.02.13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following external shared libraries are required:
 ```
 
 ```sh
-$ pyodide auditwheel copy --libdir <directory which contains libgeos_c.so> Shapely-1.8.2-cp310-cp310-emscripten_3_1_14_wasm32.whl
+$ pyodide auditwheel repair --libdir <directory which contains libgeos_c.so> Shapely-1.8.2-cp310-cp310-emscripten_3_1_14_wasm32.whl
 
 Repaired wheel has following external shared libraries:
 {
@@ -81,10 +81,6 @@ repaired_wheel = repair(
     "Shapely-1.8.2-cp310-cp310-emscripten_3_1_14_wasm32.whl",
     libdir="/path/where/shared/libraries/are/located",
     outdir="/path/to/output/directory",
-    # If set this to true, modify the needed section of WASM module.
-    # Note that is not compatible with WebAssembly dynamic linking ABI.
-    # https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md
-    modify_needed_section=False,
 )
 libs = show(repaired_wheel)
 print(libs)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ auditwheel-emscripten is a tiny tool to facilitate the creation of Python wheel 
 Python-in-the-browser using Emscripten.
 
 - `pyodide auditwheel show`: shows external shared libraries that the wheel depends on.
-- `pyodide auditwheel copy`: copies these external shared libraries into the wheel itself.
+- `pyodide auditwheel repair`: copies these external shared libraries into the wheel itself.
 
 ## Usage (CLI)
 
@@ -30,10 +30,10 @@ Python-in-the-browser using Emscripten.
 │ --help          Show this message and exit.                                                                                         │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ copy      Copy shared libraries to the wheel directory. Similar to repair but does not modify the needed section of WASM module.    │
+│ copy      [Deprecated] Copy shared libraries to the wheel directory. Works same as repair. Use repair instead.          │
 │ exports   Show exports of a wheel or a shared library file.                                                                         │
 │ imports   Show imports of a wheel or a shared library file.                                                                         │
-│ repair    [Experimental] Repair a wheel file: copy shared libraries to the wheel directory and modify the path in the wheel file.   │
+│ repair    Repair a wheel file: copy shared libraries to the wheel directory.   │
 │ show      Show shared library dependencies of a wheel or a shared library file.                                                     │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/auditwheel_emscripten/cli/main.py
+++ b/auditwheel_emscripten/cli/main.py
@@ -43,11 +43,14 @@ def _repair(
     ),
 ):
     """
-    [Experimental] Repair a wheel file: copy shared libraries to the wheel directory and modify the path in the wheel file.
+    Repair a wheel file: copy shared libraries to the wheel directory.
     """
     try:
         repaired_wheel = repair(
-            wheel_file, libdir, output_dir, modify_needed_section=True
+            wheel_file,
+            libdir,
+            output_dir,
+            modify_needed_section=False,
         )
         dependencies = show(repaired_wheel)
         pprint(dependencies)
@@ -68,16 +71,9 @@ def _copy(
     ),
 ):
     """
-    Copy shared libraries to the wheel directory. Similar to repair but does not modify the needed section of WASM module.
+    [Deprecated] Copy shared libraries to the wheel directory. Works same as `repair`. Use `repair` instead.
     """
-    try:
-        repaired_wheel = repair(
-            wheel_file, libdir, output_dir, modify_needed_section=False
-        )
-        dependencies = show(repaired_wheel)
-        pprint(dependencies)
-    except RuntimeError as e:
-        raise e
+    return _repair(wheel_file, libdir, output_dir)
 
 
 @app.command("exports")

--- a/auditwheel_emscripten/repair.py
+++ b/auditwheel_emscripten/repair.py
@@ -80,7 +80,7 @@ def repair(
     libdir: str | Path,
     outdir: str | Path | None,
     lib_sdir: str = ".libs",
-    modify_needed_section: bool = False,
+    modify_needed_section: bool = False,  # Deprecated
 ) -> Path:
     file = Path(wheel_file)
     if not file.exists():
@@ -100,10 +100,7 @@ def repair(
         tmpdir = Path(tmpdirname)
 
         extract_dir = unpack(str(wheel_file), str(tmpdir))
-        if modify_needed_section:
-            repair_extracted(extract_dir, dep_map, lib_sdir)
-        else:
-            copylib(extract_dir, dep_map, lib_sdir)
+        copylib(extract_dir, dep_map, lib_sdir)
         pack(str(extract_dir), str(outdir), None)
 
     return outdir / file.name

--- a/test/test_repair.py
+++ b/test/test_repair.py
@@ -60,7 +60,7 @@ def test_copylib(tmp_path, wheel_file, expected):
             SHAPELY_WHEEL,
             [
                 "libgeos.so.3.10.3",
-                "../../Shapely.libs/libgeos_c.so",
+                "libgeos_c.so",
             ],
         ),
     ],


### PR DESCRIPTION
Fixes `repair` command's behavior to not modify `dylink.needed` section.

It has never been properly worked, and never been integrated to emscripten or Pyodide.

This PR changes repair command to work same as copy command, and deprecate copy.