### PR TITLE
Update repair comment to patch RUNTIME_PATH

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 exclude: (^auditwheel_emscripten/emscripten_tools/)
 default_language_version:
-  python: "3.11"
+  python: "3.12"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v5.0.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.0] - 2025-04-04
+
+### Changed
+
+- `auditwheel repair` command now updates the DYLINK RPATH section of the wasm module.
+  ([#41](https://github.com/ryanking13/auditwheel-emscripten/pull/41))
+
 ## [0.0.16] - 2024-07-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ auditwheel-emscripten is a tiny tool to facilitate the creation of Python wheel 
 Python-in-the-browser using Emscripten.
 
 - `pyodide auditwheel show`: shows external shared libraries that the wheel depends on.
-- `pyodide auditwheel repair`: copies these external shared libraries into the wheel itself.
+- `pyodide auditwheel repair`: copies these external shared libraries into the wheel itself, and update the RPATH of the WASM module correspondingly.
 
 ## Usage (CLI)
 

--- a/auditwheel_emscripten/__init__.py
+++ b/auditwheel_emscripten/__init__.py
@@ -1,11 +1,10 @@
 from .exports import get_exports
 from .imports import get_imports
-from .repair import copylib, repair, repair_extracted, resolve_sharedlib
+from .repair import copylib, repair, resolve_sharedlib
 from .show import show, show_dylib, show_wheel
 
 __all__ = [
     "repair",
-    "repair_extracted",
     "resolve_sharedlib",
     "show",
     "show_wheel",

--- a/auditwheel_emscripten/__init__.py
+++ b/auditwheel_emscripten/__init__.py
@@ -1,11 +1,12 @@
 from .exports import get_exports
 from .imports import get_imports
-from .repair import copylib, repair, resolve_sharedlib
+from .repair import copylib, repair, resolve_sharedlib, modify_runtime_path
 from .show import show, show_dylib, show_wheel
 
 __all__ = [
     "repair",
     "resolve_sharedlib",
+    "modify_runtime_path",
     "show",
     "show_wheel",
     "show_dylib",

--- a/auditwheel_emscripten/cli/main.py
+++ b/auditwheel_emscripten/cli/main.py
@@ -50,7 +50,7 @@ def _repair(
             wheel_file,
             libdir,
             output_dir,
-            modify_needed_section=False,
+            modify_rpath=True,
         )
         dependencies = show(repaired_wheel)
         pprint(dependencies)

--- a/auditwheel_emscripten/emscripten_tools/webassembly.py
+++ b/auditwheel_emscripten/emscripten_tools/webassembly.py
@@ -157,6 +157,7 @@ class DylinkType(IntEnum):
     NEEDED = 2
     EXPORT_INFO = 3
     IMPORT_INFO = 4
+    RUNTIME_PATH = 5
 
 
 class InvalidWasmError(BaseException):
@@ -178,6 +179,7 @@ Dylink = namedtuple(
         "needed",
         "export_info",
         "import_info",
+        "runtime_paths",
     ],
 )
 Table = namedtuple("Table", ["elem_type", "limits"])
@@ -332,6 +334,7 @@ class Module:
         needed = []
         export_info = {}
         import_info = {}
+        runtime_paths = []
         self.read_string()  # name
 
         if dylink_section.name == "dylink":
@@ -378,6 +381,12 @@ class Module:
                         import_info.setdefault(module, {})
                         import_info[module][field] = flags
                         count -= 1
+                elif subsection_type == DylinkType.RUNTIME_PATH:
+                    count = self.read_uleb()
+                    while count:
+                        rpath = self.read_string()
+                        runtime_paths.append(rpath)
+                        count -= 1
                 else:
                     print(f"unknown subsection: {subsection_type}")
                     # ignore unknown subsections
@@ -395,6 +404,7 @@ class Module:
             needed,
             export_info,
             import_info,
+            runtime_paths,
         )
 
     @memoize

--- a/auditwheel_emscripten/module.py
+++ b/auditwheel_emscripten/module.py
@@ -76,6 +76,17 @@ class ModuleWritable(webassembly.Module):
         buf.extend(leb128.u.encode(len(subsection_buf)))
         buf.extend(subsection_buf)
 
+        # 5. RUNTIME_PATH
+        subsection_buf = bytearray()
+        subsection_buf.extend(leb128.u.encode(len(dylink.runtime_paths)))
+        for path in dylink.runtime_paths:
+            subsection_buf.extend(leb128.u.encode(len(path.encode())))
+            subsection_buf += path.encode()
+        
+        buf.extend(leb128.u.encode(DylinkType.RUNTIME_PATH))
+        buf.extend(leb128.u.encode(len(subsection_buf)))
+        buf.extend(subsection_buf)
+
         section_buf = bytearray()
 
         # custom section
@@ -115,6 +126,22 @@ class ModuleWritable(webassembly.Module):
 
         return patched_module
 
+    def patch_runtime_path(self, runtime_path: Path) -> bytes:
+        curfile = Path(self.filename).resolve()
+
+        relpath = os.path.relpath(runtime_path, curfile.parent)
+        if relpath == ".":
+            realpath_with_prefix = "$ORIGIN"
+        else:
+            realpath_with_prefix = "$ORIGIN/" + relpath
+
+        dylink_section: webassembly.Dylink = self.parse_dylink_section()
+        patched_dylink_section = dylink_section._replace(runtime_paths=[realpath_with_prefix])
+        encoded_dylink_section = self.encode_dylink_section(patched_dylink_section)
+        patched_module = self.patch_dylink(encoded_dylink_section)
+
+        return patched_module
+
 
 def parse_dylink_section(dylib: Path):
     """
@@ -126,13 +153,10 @@ def parse_dylink_section(dylib: Path):
     return dylink
 
 
-def patch_needed_libs_path(dylib: Path, dep_map: dict[str, Path]):
-    """
-    Patch needed path in dylink section
-    """
+def patch_runtime_path(dylib: Path, runtime_path: Path):
     with ModuleWritable(dylib) as m:
-        patched_module = m.patch_needed_path(dep_map)
-
+        patched_module = m.patch_runtime_path(runtime_path)
+    
     return patched_module
 
 

--- a/auditwheel_emscripten/module.py
+++ b/auditwheel_emscripten/module.py
@@ -82,7 +82,7 @@ class ModuleWritable(webassembly.Module):
         for path in dylink.runtime_paths:
             subsection_buf.extend(leb128.u.encode(len(path.encode())))
             subsection_buf += path.encode()
-        
+
         buf.extend(leb128.u.encode(DylinkType.RUNTIME_PATH))
         buf.extend(leb128.u.encode(len(subsection_buf)))
         buf.extend(subsection_buf)
@@ -136,7 +136,9 @@ class ModuleWritable(webassembly.Module):
             realpath_with_prefix = "$ORIGIN/" + relpath
 
         dylink_section: webassembly.Dylink = self.parse_dylink_section()
-        patched_dylink_section = dylink_section._replace(runtime_paths=[realpath_with_prefix])
+        patched_dylink_section = dylink_section._replace(
+            runtime_paths=[realpath_with_prefix]
+        )
         encoded_dylink_section = self.encode_dylink_section(patched_dylink_section)
         patched_module = self.patch_dylink(encoded_dylink_section)
 
@@ -156,7 +158,7 @@ def parse_dylink_section(dylib: Path):
 def patch_runtime_path(dylib: Path, runtime_path: Path):
     with ModuleWritable(dylib) as m:
         patched_module = m.patch_runtime_path(runtime_path)
-    
+
     return patched_module
 
 

--- a/auditwheel_emscripten/module.py
+++ b/auditwheel_emscripten/module.py
@@ -136,8 +136,9 @@ class ModuleWritable(webassembly.Module):
             realpath_with_prefix = "$ORIGIN/" + relpath
 
         dylink_section: webassembly.Dylink = self.parse_dylink_section()
+        original_runtime_paths = dylink_section.runtime_paths
         patched_dylink_section = dylink_section._replace(
-            runtime_paths=[realpath_with_prefix]
+            runtime_paths=original_runtime_paths + [realpath_with_prefix]
         )
         encoded_dylink_section = self.encode_dylink_section(patched_dylink_section)
         patched_module = self.patch_dylink(encoded_dylink_section)

--- a/auditwheel_emscripten/module.py
+++ b/auditwheel_emscripten/module.py
@@ -133,12 +133,16 @@ class ModuleWritable(webassembly.Module):
         if relpath == ".":
             realpath_with_prefix = "$ORIGIN"
         else:
-            realpath_with_prefix = "$ORIGIN/" + relpath
+            realpath_with_prefix = "$ORIGIN/" + Path(relpath).as_posix()
 
         dylink_section: webassembly.Dylink = self.parse_dylink_section()
-        original_runtime_paths = dylink_section.runtime_paths
+        runtime_paths = dylink_section.runtime_paths
+
+        if realpath_with_prefix not in runtime_paths:
+            runtime_paths = runtime_paths + [realpath_with_prefix]
+
         patched_dylink_section = dylink_section._replace(
-            runtime_paths=original_runtime_paths + [realpath_with_prefix]
+            runtime_paths=runtime_paths,
         )
         encoded_dylink_section = self.encode_dylink_section(patched_dylink_section)
         patched_module = self.patch_dylink(encoded_dylink_section)

--- a/auditwheel_emscripten/repair.py
+++ b/auditwheel_emscripten/repair.py
@@ -60,9 +60,7 @@ def copylib(
     return new_dep_map
 
 
-def modify_runtime_path(
-    wheel_extract_dir: str | Path, runtime_path: str
-) -> None:
+def modify_runtime_path(wheel_extract_dir: str | Path, runtime_path: str) -> None:
     """
     Patch the runtime path of shared libraries inside the wheel file
 

--- a/auditwheel_emscripten/repair.py
+++ b/auditwheel_emscripten/repair.py
@@ -4,7 +4,7 @@ from collections import deque
 from pathlib import Path
 
 from .lib_utils import get_all_shared_libs_in_dir, libdir_candidates
-from .module import patch_needed_libs_path
+from .module import patch_runtime_path
 from .show import show
 from .wheel_utils import WHEEL_INFO_RE, is_emscripten_wheel, pack, unpack
 
@@ -60,19 +60,27 @@ def copylib(
     return new_dep_map
 
 
-def repair_extracted(
-    wheel_extract_dir: str | Path,
-    dep_map: dict[str, Path],
-    lib_sdir: str,
-) -> dict[str, Path]:
-    dep_map_copied = copylib(wheel_extract_dir, dep_map, lib_sdir)
+def modify_runtime_path(
+    wheel_extract_dir: str | Path, runtime_path: str
+) -> None:
+    """
+    Patch the runtime path of shared libraries inside the wheel file
+
+    Parameters
+    ----------
+    wheel_extract_dir : str | Path
+        The directory containing the extracted wheel file
+
+    runtime_path : str
+        The target directory name where the shared libraries are located
+    """
+    runtime_path_full = Path(wheel_extract_dir) / runtime_path
+    assert runtime_path_full.exists(), f"lib directory not found: {runtime_path_full}"
 
     shared_libs = get_all_shared_libs_in_dir(wheel_extract_dir)
     for shared_lib in shared_libs:
-        patched_module = patch_needed_libs_path(shared_lib, dep_map_copied)
+        patched_module = patch_runtime_path(shared_lib, runtime_path_full)
         shared_lib.write_bytes(patched_module)
-
-    return dep_map_copied
 
 
 def repair(
@@ -80,7 +88,7 @@ def repair(
     libdir: str | Path,
     outdir: str | Path | None,
     lib_sdir: str = ".libs",
-    modify_needed_section: bool = False,  # Deprecated
+    modify_rpath: bool = True,
 ) -> Path:
     file = Path(wheel_file)
     if not file.exists():
@@ -101,6 +109,8 @@ def repair(
 
         extract_dir = unpack(str(wheel_file), str(tmpdir))
         copylib(extract_dir, dep_map, lib_sdir)
+        if modify_rpath:
+            modify_runtime_path(extract_dir, lib_sdir)
         pack(str(extract_dir), str(outdir), None)
 
     return outdir / file.name

--- a/auditwheel_emscripten/show.py
+++ b/auditwheel_emscripten/show.py
@@ -21,7 +21,7 @@ def show_wheel_unpacked(wheel_extract_dir: str | Path) -> dict[str, list[str]]:
     shared_libs = get_all_shared_libs_in_dir(wheel_extract_dir)
     for shared_lib in shared_libs:
         deps = show_dylib(shared_lib)
-        dependencies[str(shared_lib.relative_to(wheel_extract_dir))] = deps
+        dependencies[shared_lib.relative_to(wheel_extract_dir).as_posix()] = deps
 
     return dependencies
 

--- a/test/test_repair.py
+++ b/test/test_repair.py
@@ -94,7 +94,7 @@ def test_repair(tmp_path, wheel_file, expected):
                 "$ORIGIN/../../Shapely.libs",
                 "$ORIGIN",
                 "$ORIGIN",
-            ]
+            ],
         ),
     ],
 )
@@ -104,11 +104,13 @@ def test_repair_rpath(tmp_path, wheel_file, libname, expected):
     # Unpack the wheel and check individual libraries
     extract_dir = unpack(repaired_wheel, tmp_path / "unpacked")
     shared_libs = get_all_shared_libs_in_dir(extract_dir)
-    
+
     assert len(shared_libs) > 0, "No shared libraries found in the repaired wheel"
-    
+
     # Each shared library should have the correct runtime path
     for lib in shared_libs:
         lib_dylink = parse_dylink_section(lib)
         libname_index = libname.index(lib.name)
-        assert expected[libname_index] in lib_dylink.runtime_paths, f"expected runtime path {expected[libname_index]} not found in {lib.name}"
+        assert (
+            expected[libname_index] in lib_dylink.runtime_paths
+        ), f"expected runtime path {expected[libname_index]} not found in {lib.name}"

--- a/test/test_repair.py
+++ b/test/test_repair.py
@@ -1,11 +1,13 @@
 from itertools import chain
 
 import pytest
+from auditwheel_emscripten.lib_utils import get_all_shared_libs_in_dir
 from paths import SHAPELY_WHEEL, TEST_DATA
 
 from auditwheel_emscripten.repair import copylib, repair, resolve_sharedlib
 from auditwheel_emscripten.show import show
 from auditwheel_emscripten.wheel_utils import WHEEL_INFO_RE, unpack
+from auditwheel_emscripten.emscripten_tools.webassembly import parse_dylink_section
 
 
 @pytest.mark.parametrize(
@@ -66,7 +68,7 @@ def test_copylib(tmp_path, wheel_file, expected):
     ],
 )
 def test_repair(tmp_path, wheel_file, expected):
-    repaired_wheel = repair(wheel_file, TEST_DATA, tmp_path, modify_needed_section=True)
+    repaired_wheel = repair(wheel_file, TEST_DATA, tmp_path, modify_rpath=True)
 
     libs = show(repaired_wheel)
     libs_dependencies = list(chain(*libs.values()))
@@ -74,3 +76,39 @@ def test_repair(tmp_path, wheel_file, expected):
         assert (
             expected_lib in libs_dependencies
         ), f"expected lib {expected_lib} not found in dependencies"
+
+
+@pytest.mark.parametrize(
+    "wheel_file, libname, expected",
+    [
+        (
+            SHAPELY_WHEEL,
+            [
+                "_speedups.cpython-310-wasm32-emscripten.so",
+                "_vectorized.cpython-310-wasm32-emscripten.so",
+                "libgeos.so.3.10.3",
+                "libgeos_c.so",
+            ],
+            [
+                "$ORIGIN/../../Shapely.libs",
+                "$ORIGIN/../../Shapely.libs",
+                "$ORIGIN",
+                "$ORIGIN",
+            ]
+        ),
+    ],
+)
+def test_repair_rpath(tmp_path, wheel_file, libname, expected):
+    repaired_wheel = repair(wheel_file, TEST_DATA, tmp_path, modify_rpath=True)
+
+    # Unpack the wheel and check individual libraries
+    extract_dir = unpack(repaired_wheel, tmp_path / "unpacked")
+    shared_libs = get_all_shared_libs_in_dir(extract_dir)
+    
+    assert len(shared_libs) > 0, "No shared libraries found in the repaired wheel"
+    
+    # Each shared library should have the correct runtime path
+    for lib in shared_libs:
+        lib_dylink = parse_dylink_section(lib)
+        libname_index = libname.index(lib.name)
+        assert expected[libname_index] in lib_dylink.runtime_paths, f"expected runtime path {expected[libname_index]} not found in {lib.name}"

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,200 @@
+version = 1
+revision = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "auditwheel-emscripten"
+source = { editable = "." }
+dependencies = [
+    { name = "leb128" },
+    { name = "packaging" },
+    { name = "pyodide-cli" },
+    { name = "typer" },
+    { name = "wheel" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "leb128" },
+    { name = "packaging" },
+    { name = "pyodide-cli" },
+    { name = "pytest", marker = "extra == 'test'" },
+    { name = "typer" },
+    { name = "wheel" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "click"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+]
+
+[[package]]
+name = "leb128"
+version = "1.0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/3b/476c8bcb181abb060e45bca5ce9b5ba055ea9e2ed3fac6c25b2fe7b9f16b/leb128-1.0.8.tar.gz", hash = "sha256:3a52dca242f93f87a3d766380a93a3fad53ef4044f03018d21705d3b2d9021ee", size = 3361 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/97/45ab4bab1a89e6fdbc822f818bb18b39eed0dd7ed1faac8b89bc6b49a9ed/leb128-1.0.8-py3-none-any.whl", hash = "sha256:76cd271e75ea91aa2fbf7783d60cb7d667b62143d544bcee59159ff258bf4523", size = 3778 },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pyodide-cli"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rich" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/b8/99b0f6e11d505348dde9b45106944156ad5415299ba9ae5a670fad73b2b0/pyodide_cli-0.2.4.tar.gz", hash = "sha256:8cebc6831bfd234b6413d9a73178b93800bd1f6dfa1567514cbfda5768f5095b", size = 10597 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/b0/f6e406edb166a0996b85bab5e6b9764791768f2a8a3c2ab235943def55e3/pyodide_cli-0.2.4-py3-none-any.whl", hash = "sha256:286585276c7e5c7e7967c317e0432a75271e00c653bc76f836dace3034b2d2bc", size = 11299 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229 },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
+]
+
+[[package]]
+name = "typer"
+version = "0.15.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/6f/3991f0f1c7fcb2df31aef28e0594d8d54b05393a0e4e34c65e475c2a5d41/typer-0.15.2.tar.gz", hash = "sha256:ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5", size = 100711 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl", hash = "sha256:46a499c6107d645a9c13f7ee46c5d5096cae6f5fc57dd11eccbbb9ae3e44ddfc", size = 45061 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/ad/cd3e3465232ec2416ae9b983f27b9e94dc8171d56ac99b345319a9475967/typing_extensions-4.13.1.tar.gz", hash = "sha256:98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff", size = 106633 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/c5/e7a0b0f5ed69f94c8ab7379c599e6036886bffcde609969a5325f47f1332/typing_extensions-4.13.1-py3-none-any.whl", hash = "sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69", size = 45739 },
+]
+
+[[package]]
+name = "wheel"
+version = "0.45.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/98/2d9906746cdc6a6ef809ae6338005b3f21bb568bea3165cfc6a243fdc25c/wheel-0.45.1.tar.gz", hash = "sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729", size = 107545 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl", hash = "sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248", size = 72494 },
+]


### PR DESCRIPTION
Updates `auditwheel repair` command to patch RUNTIME_PATH of the webassembly module, which was added in https://github.com/WebAssembly/tool-conventions/pull/246

cc: @hoomane

- [x] changelog